### PR TITLE
fix: useRoute is not reactive #2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue2-helpers",
-  "version": "1.1.0",
+  "version": "1.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -64,9 +64,9 @@
       "dev": true
     },
     "@vue/composition-api": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@vue/composition-api/-/composition-api-1.0.4.tgz",
-      "integrity": "sha512-3OzvW8RS7/7kxE+SDXm8zSLZRy9GtCYwyLYdnGtIsqXRSt5nWkA7zu80Cw8Vg+67jglrpMdVBBy7AUXAB34ZSw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@vue/composition-api/download/@vue/composition-api-1.1.0.tgz",
+      "integrity": "sha1-SE5+O7xRatapsKmWfTFjJcI5U54=",
       "dev": true,
       "requires": {
         "tslib": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^8.2.3",
-    "@vue/composition-api": "^1.0.4",
+    "@vue/composition-api": "^1.1.0",
     "rollup": "^2.53.3",
     "rollup-plugin-terser": "^7.0.2",
     "typescript": "^4.3.5",

--- a/src/vue-router.ts
+++ b/src/vue-router.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue'
-import { computed, ComputedRef, getCurrentInstance, reactive, shallowRef } from '@vue/composition-api'
+import { computed, ComputedRef, getCurrentInstance, reactive, shallowRef, effectScope } from '@vue/composition-api'
 import VueRouter, { NavigationGuard, Route, RouterOptions } from 'vue-router'
 import { OUT_OF_SCOPE, warn } from './utils'
 
@@ -59,27 +59,20 @@ export function useRouter(): Router {
 let currentRoute: RouteLocationNormalizedLoaded
 
 export function useRoute() {
-    const router = useRouter()
     if (!currentRoute) {
-        const routeRef = shallowRef({
-            path: '/',
-            name: undefined,
-            params: {},
-            query: {},
-            hash: '',
-            fullPath: '/',
-            matched: [],
-            meta: {},
-            redirectedFrom: undefined,
-        } as Route);
-        const computedRoute = {} as {
-            [key in keyof Route]: ComputedRef<Route[key]>
-        }
-        for (const key of Object.keys(routeRef.value) as (keyof Route)[]) {
-            computedRoute[key] = computed<any>(() => routeRef.value[key])
-        }
-        router.afterEach(to => routeRef.value = to)
-        currentRoute = reactive(computedRoute)
+        const router = useRouter()
+        const scope = effectScope(true)
+        scope.run(()=> {
+            const routeRef = shallowRef(router.currentRoute);
+            const computedRoute = {} as {
+                [key in keyof Route]: ComputedRef<Route[key]>
+            }
+            for (const key of Object.keys(routeRef.value) as (keyof Route)[]) {
+                computedRoute[key] = computed<any>(() => routeRef.value[key])
+            }
+            router.afterEach(to => routeRef.value = to)
+            currentRoute = reactive(computedRoute)
+        })
     }
     return currentRoute
 }


### PR DESCRIPTION
fix #2 

This problem is because when the routing component is destroyed, the responsive content will be recycled

Use [effectScope](https://v3.vuejs.org/api/effect-scope.html) to create a global reactive

effectScope is supported in [composition-api@1.1.0](https://github.com/vuejs/composition-api/releases/tag/v1.1.0)